### PR TITLE
fix: 🐛 matirix strategy error for `[]`

### DIFF
--- a/.github/workflows/wc-terraform.yml
+++ b/.github/workflows/wc-terraform.yml
@@ -56,6 +56,7 @@ jobs:
       id-token: write
       contents: read
     timeout-minutes: 10
+    if: needs.get_diff.outputs.diff_dirs
     needs: ["get_diff"]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/wc-terraform.yml
+++ b/.github/workflows/wc-terraform.yml
@@ -135,7 +135,7 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
-    if: needs.get_diff.outputs.diff_dirs_json
+    if: needs.get_diff.outputs.diff_dirs
     needs: ["get_diff"]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Linked issue

close 

## Description

- https://github.com/torana-us/terraform-modules/actions/runs/8088631649?pr=306
  - Error when evaluating 'strategy' for job 'docs'. torana-us/terraform-modules/.github/workflows/wc-terraform.yml@2c63e74dd58d44006d6eca628102a68813222671 (Line: 143, Col: 21): Matrix vector 'target_dir' does not contain any values
    - strategy.matrix.target_dirが [] だとエラーになるっぽい？
