### PR TITLE
fix: 🐛 managed_policy_arns is deprecated, use aws_iam_role_policy_attachments_exclusive

### DIFF
--- a/aws/iam_role/README.md
+++ b/aws/iam_role/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.23.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.72.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.23.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.72.0 |
 
 ## Modules
 
@@ -21,6 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachments_exclusive.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
 | [aws_iam_policy_document.aws_assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.service_assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -29,13 +30,13 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_condition_list"></a> [aws\_condition\_list](#input\_aws\_condition\_list) | n/a | <pre>list(object({<br>    test     = string,<br>    variable = string,<br>    values   = set(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_aws_condition_list"></a> [aws\_condition\_list](#input\_aws\_condition\_list) | n/a | <pre>list(object({<br/>    test     = string,<br/>    variable = string,<br/>    values   = set(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_aws_list"></a> [aws\_list](#input\_aws\_list) | n/a | `set(string)` | `[]` | no |
 | <a name="input_custom_assume_policy_jsons"></a> [custom\_assume\_policy\_jsons](#input\_custom\_assume\_policy\_jsons) | n/a | `list(string)` | `[]` | no |
 | <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | n/a | `number` | `3600` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
 | <a name="input_policy_arns"></a> [policy\_arns](#input\_policy\_arns) | n/a | `set(string)` | n/a | yes |
-| <a name="input_service_condition_list"></a> [service\_condition\_list](#input\_service\_condition\_list) | n/a | <pre>list(object({<br>    test     = string,<br>    variable = string,<br>    values   = set(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_service_condition_list"></a> [service\_condition\_list](#input\_service\_condition\_list) | n/a | <pre>list(object({<br/>    test     = string,<br/>    variable = string,<br/>    values   = set(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_service_list"></a> [service\_list](#input\_service\_list) | n/a | `set(string)` | `[]` | no |
 
 ## Outputs

--- a/aws/iam_role/role.tf
+++ b/aws/iam_role/role.tf
@@ -1,12 +1,16 @@
 resource "aws_iam_role" "this" {
   assume_role_policy   = data.aws_iam_policy_document.base.json
   name                 = var.name
-  managed_policy_arns  = var.policy_arns
   max_session_duration = var.max_session_duration
 
   tags = {
     "Name" = var.name
   }
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "this" {
+  role_name   = aws_iam_role.this.name
+  policy_arns = var.policy_arns
 }
 
 data "aws_iam_policy_document" "base" {

--- a/aws/iam_role/versions.tf
+++ b/aws/iam_role/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.23.0"
+      version = ">= 5.72.0"
     }
   }
 }


### PR DESCRIPTION
## Linked issue

close 

## Description

- aws_iam_role.managed_policy_arnsはdeprecated.
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#example-of-exclusive-managed-policies
  - terraform-provider-aws 5.72.0 以降じゃないと使えないが、aws_iam_role_policy_attachments_exclusive に切り替える
