### PR TITLE
ci/gitleaks ignore

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -545,6 +545,7 @@ regexes = [
   '''219-09-9999''',
   '''078-05-1120''',
   '''(9[0-9]{2}|666)-\d{2}-\d{4}''',
+  '''set_real_datadog_api_key_manually''',
 ]
 paths = [
   '''(.*?)(jpg|gif|doc|pdf|bin|svg|socket|tfstate|sum)$''',

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -5,7 +5,7 @@ plugin "aws" {
 }
 
 config {
-  module = true
+  call_module_type = "all"
 }
 
 rule "terraform_naming_convention" {


### PR DESCRIPTION
## Linked issue

close 

## Description

- https://github.com/torana-us/terraform-modules/actions/runs/13166173597/job/36746729746
  - gitleaksが暴発してるのでignore
