### PR TITLE
feat: temporary_password_validity_days set 30 days

### DIFF
--- a/aws/cognito/main.tf
+++ b/aws/cognito/main.tf
@@ -29,6 +29,9 @@ resource "aws_cognito_user_pool" "this" {
     }
   }
 
+  password_policy {
+    temporary_password_validity_days = 30
+  }
 }
 
 resource "aws_cognito_user_pool_domain" "this" {

--- a/aws/cognito/main.tf
+++ b/aws/cognito/main.tf
@@ -30,6 +30,11 @@ resource "aws_cognito_user_pool" "this" {
   }
 
   password_policy {
+    minimum_length                   = 8
+    require_lowercase                = false
+    require_numbers                  = false
+    require_symbols                  = false
+    require_uppercase                = false
     temporary_password_validity_days = 30
   }
 }


### PR DESCRIPTION
## Linked issue

close 

## Description

- Cognito Userpoolへのユーザ登録時の仮パスワード有効期間を30日に延長
  - defaultは24h
